### PR TITLE
Movenet update requirements

### DIFF
--- a/example/movenet/requirements.txt
+++ b/example/movenet/requirements.txt
@@ -1,5 +1,5 @@
 -i https://download.pytorch.org/whl/cu118
-numpy~=1.23.5
+numpy~=1.24.1
 pandas==1.5.3.
 opencv-python~=4.5.5.62
 torch==2.0.0

--- a/example/movenet/requirements.txt
+++ b/example/movenet/requirements.txt
@@ -1,6 +1,6 @@
--i https://download.pytorch.org/whl/cu118
+--extra-index-url https://download.pytorch.org/whl/cu118
 numpy~=1.24.1
-pandas
+pandas~=1.5.3
 opencv-python~=4.5.5.62
 torch==2.0.0
 torchvision==0.15.0

--- a/example/movenet/requirements.txt
+++ b/example/movenet/requirements.txt
@@ -1,6 +1,6 @@
 -i https://download.pytorch.org/whl/cu118
 numpy~=1.24.1
-pandas==1.5.3
+pandas
 opencv-python~=4.5.5.62
 torch==2.0.0
 torchvision==0.15.0

--- a/example/movenet/requirements.txt
+++ b/example/movenet/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://download.pytorch.org/whl/cu118
 numpy~=1.24.1
 pandas~=1.5.3
 opencv-python~=4.5.5.62

--- a/example/movenet/requirements.txt
+++ b/example/movenet/requirements.txt
@@ -1,6 +1,6 @@
 -i https://download.pytorch.org/whl/cu118
 numpy~=1.24.1
-pandas==1.5.3.
+pandas==1.5.3
 opencv-python~=4.5.5.62
 torch==2.0.0
 torchvision==0.15.0

--- a/example/movenet/requirements.txt
+++ b/example/movenet/requirements.txt
@@ -1,10 +1,11 @@
-numpy~=1.21.4
-pandas==1.4.0
+-i https://download.pytorch.org/whl/cu118
+numpy~=1.23.5
+pandas==1.5.3.
 opencv-python~=4.5.5.62
-torch==1.10.2
-torchvision==0.11.3
+torch==2.0.0
+torchvision==0.15.0
 albumentations~=1.1.0
-Pillow~=8.4.0
+Pillow~=9.0.1
 torchsummary~=1.5.1
 onnxruntime
 tensorboard


### PR DESCRIPTION
The original pytorch version specified in the `movenet` [requirements](https://github.com/event-driven-robotics/hpe-core/blob/a664e3b1a377afc01af76b98b40071e953fd3a6c/example/movenet/requirements.txt#L4) is outdated, and not compatible with recent NVIDIA GPUs (e.g. RTX 3000 series), resulting in the inability to run the pose detection algorithm, throwing
```bash
RuntimeError: CUDA error: no kernel image is available for execution on the device
```
Beside pytorch, related libraries have been updated for compatibility.