### PR TITLE
Recompute MPJPE metric by adding a condition to ignore -inf values in GT_joints of some samples

### DIFF
--- a/evaluation/evaluate_hpe.py
+++ b/evaluation/evaluate_hpe.py
@@ -756,7 +756,7 @@ def main(args):
                     results['global']['mpjpe'] = dict()
 
                 if algo_name not in results['global']['mpjpe'].keys():
-                    results['global']['mpjpe'][algo_name] = metrics_utils.RMSE()
+                    results['global']['mpjpe'][algo_name] = metrics_utils.MPJPE() #update MPJPE metric
 
                 mpjpe = results['global']['mpjpe'][algo_name]
                 mpjpe.update_samples(skeletons_pred1K, skeletons_gt1K)

--- a/evaluation/utils/metrics.py
+++ b/evaluation/utils/metrics.py
@@ -153,7 +153,9 @@ class MPJPE:
         count = np.zeros((13))
         for i in range(13):
             for j in range(len(self.gt_joints)):
-                if(self.predicted_joints[j,i,0]!=0 and self.predicted_joints[j,i,1]!=0):
+                # ignore -inf values in ground truth joints
+                if(self.predicted_joints[j,i,0]!=0 and self.predicted_joints[j,i,1]!=0 and self.gt_joints[j,i,1] > 0 
+                   and self.gt_joints[j,i,0] > 0):
                     dist[j,i] = np.linalg.norm(self.predicted_joints[j,i,:] - self.gt_joints[j,i,:], axis=0)
                     count[i] = count[i] + 1
         res = np.sum(dist, axis=0) / count

--- a/evaluation/utils/plots.py
+++ b/evaluation/utils/plots.py
@@ -26,7 +26,7 @@ RENAMING = {'movenet_cam-24': 'moveEnet',
             'movenet_eF': 'movenet_fixedCount',
             'movenet': 'moveEnet',
             'gl-hpe':'liftmono-hpe',
-            'hpeGnn_splineConv':'ledge_singleweight_stepwise'
+            'hpeGnn_splineConv':'gnn'
             }
 
 

--- a/evaluation/utils/plots.py
+++ b/evaluation/utils/plots.py
@@ -25,7 +25,8 @@ OTHER_COLORS = ['black', 'violet','grey']
 RENAMING = {'movenet_cam-24': 'moveEnet',
             'movenet_eF': 'movenet_fixedCount',
             'movenet': 'moveEnet',
-            'gl-hpe':'liftmono-hpe'
+            'gl-hpe':'liftmono-hpe',
+            'hpeGnn_splineConv':'ledge_singleweight_stepwise'
             }
 
 


### PR DESCRIPTION
-  Ignored -inf values in GT joints of some samples and recompute MPJPE metric
- Update MPJPE metric in the results dict() (instead, it update RMSE metric previously)

The PCK metric and MPJPE plot evaluated at 120 validation data samples in every algorithm are updated: 
- Openpose rgb have lowest MPJPE value as we expected
![global_pck](https://github.com/user-attachments/assets/3c8527f7-33b9-4a98-bd4b-080186136af6)
![mpjpe](https://github.com/user-attachments/assets/d52583b0-3a0f-4ba1-b304-a028639bf41c)
