### PR TITLE
Link update for gl-hpe checkpoint

### DIFF
--- a/example/yarp-glhpe/README.md
+++ b/example/yarp-glhpe/README.md
@@ -18,7 +18,7 @@ The software was tested on Ubuntu 20.04.2 LTS without GPU support.
 :bulb: `<workspace>` is the parent directory in which the repository is cloned
 
 ## Usage
-- Download the pre-trained model from [here](https://drive.google.com/drive/folders/1AgsQl6sTJBygPvgbdR1e9IfVAYxupMGI) and store it into folder `/path/to/pre/trained/model/folder`
+- Download the pre-trained model from [here](https://drive.google.com/file/d/1z1XLPWMVsTpSZnXP8ERXHcR0dss_dhwy/view?usp=drive_link) and store it into folder `/path/to/pre/trained/model/folder`
 - Run the Docker container
     ```shell
     $ xhost +


### PR DESCRIPTION
Updated link for GL-HPE example's checkpoint, which is almost 300MB, and thus, hosted on google drive.